### PR TITLE
Oppdaterer v1 med bl.a. versjonsinfo (ved å merge fra develop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# SKOS-AP-NO - Forvaltningsstandard for tilgjengeliggjøring av begrepsbeskrivelser basert på SKOS (SKOS-AP-NO-Begrep) med tilhørende ontologi
+# SKOS-AP-NO-Begrep – Forvaltningsstandard for tilgjengeliggjøring av begrepsbeskrivelser basert på SKOS
 
-For revisjon av Forvaltningsstandard for tilgjengeliggjøring av begrepsbeskrivelser basert på SKOS (https://data.norge.no/specification/skos-ap-no-begrep) og ontologi. 
+For forvaltning av SKOS-AP-NO-Begrep, med tilhørende ontologi, eksempler og valideringsregler.
 
-Klikk på Issues og deretter New issue for å melde inn endringsbehov og endringsforslag. Det forutsetter at du har registrert deg som bruker på GitHub, med den fordelen at vi lettere kan få tak i deg for ev. avklaringsspørsmål.
+Gjeldende versjon: https://data.norge.no/specification/skos-ap-no-begrep/
+Redaktørens utkast: https://informasjonsforvaltning.github.io/skos-ap-no-begrep/
+
 
 \- _Digitaliseringsdirektoratet / Norwegian Digitalisation Agency_ (https://digdir.no)

--- a/docs/main.adoc
+++ b/docs/main.adoc
@@ -1,5 +1,5 @@
 include::locale/attributes.adoc[]
-= Forvaltningsstandard for tilgjengeliggjøring av begrepsbeskrivelser basert på SKOS (SKOS-AP-NO-Begrep) - Versjon 1.0.3
+= SKOS-AP-NO-Begrep – Forvaltningsstandard for tilgjengeliggjøring av begrepsbeskrivelser basert på SKOS
 :description: Forvaltningsstandard for tilgjengeliggjøring av begrepsbeskrivelser basert på SKOS (SKOS-AP-NO-Begrep)
 :doctype: book
 :docinfo:
@@ -12,11 +12,12 @@ include::locale/attributes.adoc[]
 
 image::digitaliseringsdirektoratet.png[width=50%, pdfwidth=30vw]
 
+*Status*: Gjeldende +
+*Versjon*: 1.0.3 (se <<Endringslogg, endringslogg>>) +
 *Publisert*: 2019-03-15 (v.1.0) +
 *Oppdatert*: 2020-07-01 (v.1.0.3) +
-*Status*: Gjeldende
-
-// WARNING: Det foregår redaksjonelle justeringer av denne forvaltningsstandarden.
+*Gjeldende versjon*: https://data.norge.no/specification/skos-ap-no-begrep/ +
+*Redaktørens utkast*: https://informasjonsforvaltning.github.io/skos-ap-no-begrep/
 
 //:sectnums:
 

--- a/docs/vedlegg-b.adoc
+++ b/docs/vedlegg-b.adoc
@@ -1,6 +1,6 @@
-== Vedlegg B (ikke-normativt) - Endringer fra versjon 1.0 til 1.0.x
+== Vedlegg B (ikke-normativt) - Endringer fra versjon 1.0 til 1.0.x [[Endringslogg]]
 
-Det er kun redaksjonelle endringer fra versjon 1.0 til 1.0.x, som ikke beskrives her i vedlegget. 
+Det er kun redaksjonelle endringer fra versjon 1.0 til 1.0.x, som ikke beskrives her i vedlegget.
 Med redaksjonelle endringer menes endringer i formatering/strukturering eller justeringer i tekst/tegninger/tabeller/eksempler
 som ikke endrer kravene i standarden.
 mailto:informasjonsforvaltning@digdir.no[Ta kontakt med Digitaliseringsdirektoratet] for mer informasjon om de redaksjonelle endringene.


### PR DESCRIPTION
Dette som et ledd i å bygge opp samme struktur som for DCAT-AP-NO (dvs. med branchene develop, v1, osv.). 

@tafjord Til din info har Stig godkjent develop-branch, som nå merges til v1 (som går ut til data.norge.no).