### PR TITLE
develop -> v1

### DIFF
--- a/docs/main.adoc
+++ b/docs/main.adoc
@@ -13,8 +13,8 @@ include::locale/attributes.adoc[]
 image::digitaliseringsdirektoratet.png[width=50%, pdfwidth=30vw]
 
 *Status*: Gjeldende +
-*Versjon*: 1.0.6 (se <<Endringslogg, endringslogg>>) +
-*Publisert*: 2019-03-15 (v.1.0) +
+*Versjon*: 1.1 (se <<Endringslogg, endringslogg>>) +
+*Publisert*: 2019-03-15 (v.1.0), 2021-03-25 (v.1.1) +
 *Oppdatert*: 2021-03-25 +
 *Gjeldende versjon*: https://data.norge.no/specification/skos-ap-no-begrep/ +
 *Redaktørens utkast*: https://informasjonsforvaltning.github.io/skos-ap-no-begrep/

--- a/docs/spesifikasjon-felter.adoc
+++ b/docs/spesifikasjon-felter.adoc
@@ -171,8 +171,8 @@ dct:modified "2018-01-01"^^xsd:date ; ] .
 === Begrep.assosiativRelasjon
 [cols="35s,65", stripes=odd]
 |===
-|URI til definisjon |skos:related
-|SKOS (RDF turtle)-representasjon |<> skos:related <> .
+|URI til definisjon | skosno:assosiativRelasjon
+|SKOS (RDF turtle)-representasjon | <> skosno:assosiativRelasjon [ a skosno:AssosiativRelasjon ; ] <> .
 |Datatype (med ev. URI til definisjon) |skos:Concept
 |Merknad |(ingen)
 |===
@@ -180,8 +180,8 @@ dct:modified "2018-01-01"^^xsd:date ; ] .
 === Begrep.generiskRelasjon
 [cols="35s,65", stripes=odd]
 |===
-|URI til definisjon |xkos:generalizes
-|SKOS (RDF turtle)-representasjon | <> xkos:generalizes <> .
+|URI til definisjon | skosno:generiskRelasjon
+|SKOS (RDF turtle)-representasjon | <> skosno:generiskRelasjon [ a skosno:GeneriskRelasjon ; ] <> .
 |Datatype (med ev. URI til definisjon) |skos:Concept
 |Merknad |(ingen)
 |===
@@ -189,8 +189,8 @@ dct:modified "2018-01-01"^^xsd:date ; ] .
 === Begrep.partitivRelasjon
 [cols="35s,65", stripes=odd]
 |===
-|URI til definisjon |xkos:hasPart
-|SKOS (RDF turtle)-representasjon |<> xkos:hasPart <> .
+|URI til definisjon | skosno:partitivRelasjon
+|SKOS (RDF turtle)-representasjon | <> skosno:partitivRelasjon [ a skosno:PartitivRelasjon ; ] <> .
 |Datatype (med ev. URI til definisjon) |skos:Concept
 |Merknad |(ingen)
 |===
@@ -460,84 +460,72 @@ dct:modified “2017-01-01”^^xsd:date;
 
 === AssosiativRelasjon.beskrivelse.tekst
 
-WARNING: [yellow-background]#SKOS (RDF title)-representasjonen som er vist i tabellen under, er feil. Den skal ikke brukes slik den nå er. Ny løsning er på vei.#
-
 [cols="35s,65", stripes=odd]
 |===
 |URI til definisjon |dct:description
-|SKOS (RDF turtle)-representasjon | [.line-through]#<>
-skos:related [ a skosno:AssosiativRelasjon ;
-dct:description “”@nb ; ] .#
+|SKOS (RDF turtle)-representasjon | <etBegrep>
+skosno:assosiativRelasjon [ a skosno:AssosiativRelasjon ;
+dct:description “beskrivelsen av relasjonen”@nb ; skos:related <etAnnetBegrep> ; ] .
 |Datatype (med ev. URI til definisjon) |rdfs:Literal
 |Merknad |(ingen)
 |===
 
 === AssosiativRelasjon.beskrivelse.språkMålform
 
-WARNING: [yellow-background]#SKOS (RDF title)-representasjonen som er vist i tabellen under, er feil. Den skal ikke brukes slik den nå er. Ny løsning er på vei.#
-
 [cols="35s,65", stripes=odd]
 |===
 |URI til definisjon |dct:description
-|SKOS (RDF turtle)-representasjon | [.line-through]#<>
-skos:related [ a skosno:AssosiativRelasjon ;
-dct:description “”@nb ; ] .#
+|SKOS (RDF turtle)-representasjon | <etBegrep>
+skosno:assosiativRelasjon [ a skosno:AssosiativRelasjon ;
+dct:description “beskrivelsen av relasjonen”@nb ; skos:related <etAnnetBegrep> ; ] .
 |Datatype (med ev. URI til definisjon) |rdfs:Literal
 |Merknad |(ingen)
 |===
 
 === GeneriskRelasjon.inndelingskriterium.tekst
 
-WARNING: [yellow-background]#SKOS (RDF title)-representasjonen som er vist i tabellen under, er feil. Den skal ikke brukes slik den nå er. Ny løsning er på vei.#
-
 [cols="35s,65", stripes=odd]
 |===
 |URI til definisjon |dct:description
-|SKOS (RDF turtle)-representasjon | [.line-through]#<>
-xkos:generalizes [ a skosno:GeneriskRelasjon ;
-skosno:inndelingskriterium “”@nb ; ] .#
+|SKOS (RDF turtle)-representasjon | <etBegrep>
+skosno:generiskRelasjon [ a skosno:GeneriskRelasjon ;
+skosno:inndelingskriterium “inndelingskriteriet for relasjonen”@nb ; xkos:generalizes <etAnnetBegrep> ; ] .
 |Datatype (med ev. URI til definisjon) |rdfs:Literal
 |Merknad |(ingen)
 |===
 
 === GeneriskRelasjon.inndelingskriterium.språkMålform
 
-WARNING: [yellow-background]#SKOS (RDF title)-representasjonen som er vist i tabellen under, er feil. Den skal ikke brukes slik den nå er. Ny løsning er på vei.#
-
 [cols="35s,65", stripes=odd]
 |===
 |URI til definisjon |dct:description
-|SKOS (RDF turtle)-representasjon | [.line-through]#<>
-xkos:generalizes [ a skosno:GeneriskRelasjon ;
-skosno:inndelingskriterium “”@nb ; ] .#
+|SKOS (RDF turtle)-representasjon | <etBegrep>
+skosno:generiskRelasjon [ a skosno:GeneriskRelasjon ;
+skosno:inndelingskriterium “inndelingskriteriet for relasjonen”@nb ; xkos:generalizes <etAnnetBegrep> ; ] .
 |Datatype (med ev. URI til definisjon) |rdfs:Literal
 |Merknad |(ingen)
 |===
 
 === PartitivRelasjon.inndelingskriterium.tekst
 
-WARNING: [yellow-background]#SKOS (RDF title)-representasjonen som er vist i tabellen under, er feil. Den skal ikke brukes slik den nå er. Ny løsning er på vei.#
-
 [cols="35s,65", stripes=odd]
 |===
 |URI til definisjon |dct:description
-|SKOS (RDF turtle)-representasjon | [.line-through]#<>
-xkos:hasPart [ a skosno:PartitivRelasjon ;
-skosno:inndelingskriterium “”@nb ; ] .#
+|SKOS (RDF turtle)-representasjon | <etBegrep>
+skosno:partitivRelasjon [ a skosno:PartitivRelasjon ;
+skosno:inndelingskriterium “inndelingskriteriet for relasjonen”@nb ; xkos:hasPart <etAnnetBegrep> ; ] .
 |Datatype (med ev. URI til definisjon) |rdfs:Literal
 |Merknad |(ingen)
 |===
 
 === PartitivRelasjon.inndelingskriterium.språkMålform
 
-WARNING: [yellow-background]#SKOS (RDF title)-representasjonen som er vist i tabellen under, er feil. Den skal ikke brukes slik den nå er. Ny løsning er på vei.#
-
 [cols="35s,65", stripes=odd]
 |===
 |URI til definisjon |dct:description
-|SKOS (RDF turtle)-representasjon | [.line-through]#<>
-xkos:hasPart [ a skosno:PartitivRelasjon ;
-skosno:inndelingskriterium “”@nb ; ] .#
+|SKOS (RDF turtle)-representasjon | <etBegrep>
+skosno:partitivRelasjon [ a skosno:PartitivRelasjon ;
+skosno:inndelingskriterium “inndelingskriteriet for relasjonen”@nb ; xkos:hasPart <etAnnetBegrep> ; ] .
 |Datatype (med ev. URI til definisjon) |rdfs:Literal
 |Merknad |(ingen)
 |===

--- a/docs/vedlegg-b.adoc
+++ b/docs/vedlegg-b.adoc
@@ -1,6 +1,14 @@
-== Vedlegg B (ikke-normativt) - Endringer fra versjon 1.0 til 1.0.x [[Endringslogg]]
+== Vedlegg B (ikke-normativt) - Endringer fra versjon 1.0 til 1.1 [[Endringslogg]]
 
-Det er kun redaksjonelle endringer fra versjon 1.0 til 1.0.x, som ikke beskrives her i vedlegget.
-Med redaksjonelle endringer menes endringer i formatering/strukturering eller justeringer i tekst/tegninger/tabeller/eksempler
-som ikke endrer kravene i standarden.
-mailto:informasjonsforvaltning@digdir.no[Ta kontakt med Digitaliseringsdirektoratet] for mer informasjon om de redaksjonelle endringene.
+I tillegg til noen redaksjonelle justeringer som er foretatt siden v.1.0.0, er den viktigste endringen fra v.1.0.x til v.1.1 å rette opp (skrive)feil i RDF-representasjonene for hhv. assosiativ relasjon, generisk relasjon og partitiv relasjon mellom begreper, som forklart i tabellen under.
+
+[cols="15,15,35,35"]
+|===
+|*Egenskap*|*RDF-representasjon v.1.1*|*RDF-representasjon v.1.0.x*|*Begrunnelse*
+|Begrep.assosiativRelasjon|<> skosno:assosiativRelasjon [ a skosno:AssosiativRelasjon ; ] <>|+++<s>+++<> skos:related <> .+++</s>+++|Skrivefeil i v.1.0.x. skos:related har skos:Concept som range. Den kan bare brukes til å referere til et annet begrep og ikke til en begrepsrelasjon.
+|Begrep.generiskRelasjon|<> skosno:generiskRelasjon [ a skosno:GeneriskRelasjon ; ] <> .|+++<s>+++<> xkos:generalizes <> .+++</s>+++|Skrivefeil i v.1.0.x xkos:generalizes har skos:Concept som range. Den kan bare brukes til å referere til et annet begrep og ikke til en begrepsrelasjon.
+|Begrep.partitivRelasjon|<> skosno:partitivRelasjon [ a skosno:PartitivRelasjon ; ] <> .|+++<s>+++<> xkos:hasPart <> .+++</s>+++|Skrivefeil i v.1.0.x xkos:hasPart har skos:Concept som range. Den kan bare brukes til å referere til et annet begrep og ikke til en begrepsrelasjon.
+|AssosiativRelasjon.beskrivelse.tekst; AssosiativRelasjon.beskrivelse.språkMålform|<etBegrep>|+++<s>+++<> skos:related [ a skosno:AssosiativRelasjon ; dct:description “”@nb ; ] .+++</s>+++|Skrivefeil i v.1.0.x skos:related har skos:Concept som range. Den kan bare brukes til å referere til et annet begrep og ikke til en begrepsrelasjon.
+|GeneriskRelasjon.inndelingskriterium.tekst; GeneriskRelasjon.inndelingskriterium.språkMålform |<etBegrep>|+++<s>+++<> xkos:generalizes [ a skosno:GeneriskRelasjon ; skosno:inndelingskriterium “”@nb ; ] .+++</s>+++|Skrivefeil i v.1.0.x xkos:generalizes har skos:Concept som range. Den kan bare brukes til å referere til et annet begrep og ikke til en begrepsrelasjon.
+|PartitivRelasjon.inndelingskriterium.tekst; PartitivRelasjon.inndelingskriterium.språkMålform|<etBegrep>|+++<s>+++<> xkos:hasPart [ a skosno:PartitivRelasjon ; skosno:inndelingskriterium “”@nb ; ] .+++</s>+++|Skrivefeil i v.1.0.x xkos:hasPart har skos:Concept som range. Den kan bare brukes til å referere til et annet begrep og ikke til en begrepsrelasjon.
+|===


### PR DESCRIPTION
Stig: Joachim har godkjent develop, som nå merges til v1 for publisering på data.norge.no. 

Jeg har dessuten "tagget" v.1.0.x som egen release og låst den i safen. Har også lastet ned PDF-versjonen i tilfelle noen savner forrige versjon. 