### PR TITLE
Oppdateringer 2021-08-26

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# SKOS-AP-NO-Begrep - examples
+
+This folder contains some examples for how to use SKOS-AP-NO-Begrep, in RDF Turtle.

--- a/examples/exAssosiativeRelasjoner.ttl
+++ b/examples/exAssosiativeRelasjoner.ttl
@@ -1,0 +1,53 @@
+#####
+# Eksempler på assosiative relasjoner mellom begreper
+# Skal _ikke_ gi valideringsfeil
+#    bortsett fra ev. feil på instanser av skos:Concept som det blir pekt på herfra
+###
+
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix skosno: <https://data.norge.no/vocabulary/skosno#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
+@prefix xkos: <http://rdf-vocabulary.ddialliance.org/xkos#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <https://examples.com/concepts/> .
+
+##### Dette første eksemplet viser bruken av alle mulige egenskaper relatert til assoviate relasjoner mellom begreper
+
+# begrepet 'bil':
+:bil a skos:Concept;  # Begrep
+  # --- mandatory, for selve begrepet:
+    dct:identifier <https://examples.com/concepts/bil> ; # identifikator
+    skosxl:prefLabel [ a skosxl:Label ; # anbefaltTerm
+      skosxl:literalForm "bil"@nb ; # navn
+      ] ;
+    skosno:definisjon [ a skosno:Definisjon ; # definisjon
+    	rdfs:label "her kommer definisjonsteksten ..."@nb ; # definisjonsteksten
+    	] ;
+    dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ; # ansvarligVirksomhet
+  # --- optional, herunder assosiative relasjoner:
+    skosno:assosiativRelasjon [ a skosno:AssosiativRelasjon ; # assosiativRelasjon
+      # --- mandatory:
+        skos:related :vei ; # assosiertBegrep
+        dct:description "kjører på"@nb; # beskrivelse
+      # --- optional:
+        dct:modified "2021-08-01"^^xsd:date ; # sistOppdatert
+      ] ;
+  .
+
+#### Eksemplene herfra inneholder stort sett kun obligatoriske egenskaper
+
+# begrepet 'vei':
+:vei a skos:Concept;  # Begrep
+  # --- mandatory, for selve begrepet:
+    dct:identifier <https://examples.com/concepts/vei> ; # identifikator
+    skosxl:prefLabel [ a skosxl:Label ; # anbefaltTerm
+      skosxl:literalForm "vei"@nb ; # navn
+      ] ;
+    skosno:definisjon [ a skosno:Definisjon ; # definisjon
+    	rdfs:label "her kommer definisjonsteksten ..."@nb ; # definisjonsteksten
+    	] ;
+    dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ; # ansvarligVirksomhet
+ .

--- a/examples/exGeneriskeRelasjoner.ttl
+++ b/examples/exGeneriskeRelasjoner.ttl
@@ -1,0 +1,120 @@
+#####
+# Eksempler på generiske relasjoner mellom begreper
+# Skal _ikke_ gi valideringsfeil
+#    bortsett fra ev. feil på instanser av skos:Concept som det blir pekt på herfra
+###
+
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix skosno: <https://data.norge.no/vocabulary/skosno#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
+@prefix xkos: <http://rdf-vocabulary.ddialliance.org/xkos#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <https://examples.com/concepts/> .
+
+##### Dette første eksemplet viser bruken av alle mulige egenskaper relatert til generiske relasjoner mellom begreper
+
+# begrepet 'bestikk':
+:bestikk a skos:Concept;  # Begrep
+  # --- mandatory, for selve begrepet:
+    dct:identifier <https://examples.com/concepts/bestikk> ; # identifikator
+    skosxl:prefLabel [ a skosxl:Label ; # anbefaltTerm
+      skosxl:literalForm "bestikk"@nb ; # navn
+      ] ;
+    skosno:definisjon [ a skosno:Definisjon ; # definisjon
+    	rdfs:label "redskap som man bruker til å håndtere maten under et måltid eller når man spiser"@nb ; # definisjonsteksten
+    	] ;
+    dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ; # ansvarligVirksomhet
+  # --- optional, herunder generiske relasjoner:
+    skosno:generiskRelasjon [ a skosno:GeneriskRelasjon ; # generiskRelasjon
+      # --- mandatory (minst 1 overordnetBegrep eller 1 underordetBegrep):
+        xkos:generalizes :fiskebestikk ; # underordnetBegrep
+      # --- optional:
+        skosno:inndelingskriterium "bruksformål"@nb; # inndelingskriterium
+        dct:modified "2021-08-01"^^xsd:date ; # sistOppdatert
+      ] ;
+    skosno:generiskRelasjon [ a skosno:GeneriskRelasjon ; # generiskRelasjon
+      # --- mandatory (minst 1 overordnetBegrep eller 1 underordetBegrep):
+        xkos:generalizes :biffbestikk ; # underordnetBegrep
+      # --- optional:
+        skosno:inndelingskriterium "bruksformål"@nb; # inndelingskriterium
+        dct:modified "2021-08-01"^^xsd:date ; # sistOppdatert
+      ] ;
+    skosno:generiskRelasjon [ a skosno:GeneriskRelasjon ; # generiskRelasjon
+      # --- mandatory (minst 1 overordnetBegrep eller 1 underordetBegrep):
+        xkos:generalizes :sølvbestikk ; # underordnetBegrep
+      # --- optional:
+        skosno:inndelingskriterium "materiale"@nb; # inndelingskriterium
+        dct:modified "2021-08-24"^^xsd:date ; # sistOppdatert
+      ] ;
+    skosno:generiskRelasjon [ a skosno:GeneriskRelasjon ; # generiskRelasjon
+      # --- mandatory (minst 1 overordnetBegrep eller 1 underordetBegrep):
+        xkos:generalizes :stålbestikk ; # underordnetBegrep
+      # --- optional:
+        skosno:inndelingskriterium "materiale"@nb; # inndelingskriterium
+        dct:modified "2021-08-24"^^xsd:date ; # sistOppdatert
+      ] ;
+  .
+
+#### Eksemplene herfra inneholder stort sett kun obligatoriske egenskaper
+
+# begrepet 'fiskebestikk':
+:fiskebestikk a skos:Concept;  # Begrep
+  # --- mandatory, for selve begrepet:
+    dct:identifier <https://examples.com/concepts/fiskebestikk> ; # identifikator
+    skosxl:prefLabel [ a skosxl:Label ; # anbefaltTerm
+      skosxl:literalForm "fiskebestikk"@nb ; # navn
+      ] ;
+    skosno:definisjon [ a skosno:Definisjon ; # definisjon
+    	rdfs:label "bestikk til å spise fisk med"@nb ; # definisjonsteksten
+    	] ;
+    dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ; # ansvarligVirksomhet
+  # --- optional, herunder generiske relasjoner:
+    skosno:generiskRelasjon [ a skosno:GeneriskRelasjon ; # generisk relasjon
+      # --- mandatory (minst 1 overordnetBegrep eller 1 underordetBegrep):
+        xkos:specializes :bestikk ; # overordnetBegrep
+      # --- optional:
+        skosno:inndelingskriterium "bruksformål"@nb; # inndelingskriterium
+        dct:modified "2021-08-01"^^xsd:date ; # sistOppdatert
+      ] .
+
+# begrepet 'biffbestikk':
+:biffbestikk a skos:Concept;  # Begrep
+  # --- mandatory, for selve begrepet:
+    dct:identifier <https://examples.com/concepts/biffbestikk> ; # identifikator
+    skosxl:prefLabel [ a skosxl:Label ; # anbefaltTerm
+      skosxl:literalForm "biffbestikk"@nb ; # navn
+      ] ;
+    skosno:definisjon [ a skosno:Definisjon ; # definisjon
+    	rdfs:label "bestikk til å spise biff med"@nb ; # definisjonsteksten
+    	] ;
+    dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ; # ansvarligVirksomhet
+  .
+
+# begrepet 'sølvbestikk':
+:sølvbestikk a skos:Concept;  # Begrep
+  # --- mandatory, for selve begrepet:
+  dct:identifier <https://examples.com/concepts/sølvbestikk> ; # identifikator
+  skosxl:prefLabel [ a skosxl:Label ; # anbefaltTerm
+    skosxl:literalForm "sølvbestikk"@nb ; # navn
+    ] ;
+  skosno:definisjon [ a skosno:Definisjon ; # definisjon
+  	rdfs:label "bestikk laget av sølv"@nb ; # definisjonsteksten
+  	] ;
+  dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ; # ansvarligVirksomhet
+  .
+
+# begrepet 'stålbestikk':
+:stålbestikk a skos:Concept;  # Begrep
+  # --- mandatory, for selve begrepet:
+  dct:identifier <https://examples.com/concepts/stålbestikk> ; # identifikator
+  skosxl:prefLabel [ a skosxl:Label ; # anbefaltTerm
+    skosxl:literalForm "stålbestikk"@nb ; # navn
+    ] ;
+  skosno:definisjon [ a skosno:Definisjon ; # definisjon
+  	rdfs:label "bestikk laget av stål"@nb ; # definisjonsteksten
+  	] ;
+  dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ; # ansvarligVirksomhet
+  .

--- a/examples/exPartitiveRelasjoner.ttl
+++ b/examples/exPartitiveRelasjoner.ttl
@@ -1,0 +1,80 @@
+#####
+# Eksempler på partitive relasjoner mellom begreper
+# Skal _ikke_ gi valideringsfeil
+#    bortsett fra ev. feil på instanser av skos:Concept som det blir pekt på herfra
+###
+
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix skosno: <https://data.norge.no/vocabulary/skosno#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
+@prefix xkos: <http://rdf-vocabulary.ddialliance.org/xkos#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <https://examples.com/concepts/> .
+
+##### Dette første eksemplet viser bruken av alle mulige egenskaper relatert til partitive relasjoner mellom begreper
+
+# begrepet 'virksomhet':
+:virksomhet a skos:Concept;  # Begrep
+  # --- mandatory, for selve begrepet:
+    dct:identifier <hhttps://examples.com/concepts/virksomhet> ; # identifikator
+    skosxl:prefLabel [ a skosxl:Label ; # anbefaltTerm
+      skosxl:literalForm "virksomhet"@nb ; # navn
+      ] ;
+    skosno:definisjon [ a skosno:Definisjon ; # definisjon
+    	rdfs:label "her kommer definisjonsteksten ..."@nb ; # definisjonsteksten
+    	] ;
+    dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ; # ansvarligVirksomhet
+  # --- optional, herunder partitive relasjoner:
+    skosno:partitivRelasjon [ a skosno:PartitivRelasjon ;  # partitivRelasjon
+      # --- mandatory (minst 1 overordnetBegrep eller 1 underordetBegrep):
+        dct:hasPart :organisatoriskEnhet ; # underordnetBegrep
+      # --- optional:
+        dct:description "funksjon"@nb ; # inndelingskriterium
+        dct:modified "2021-01-01"^^xsd:data ; # sistOppdatert
+    ] ;
+  skosno:partitivRelasjon [ a skosno:PartitivRelasjon ;  # partitivRelasjon
+    # --- mandatory (minst 1 overordnetBegrep eller 1 underordetBegrep):
+      dct:hasPart :geografiskEnhet ; # underordnetBegrep # underordnetBegrep
+    # --- optional:
+      dct:description "lokasjon"@nb ; # inndelingskriterium
+      dct:modified "2021-08-01"^^xsd:data ; # sistOppdatert
+  ] ;
+  .
+
+#### Eksemplene herfra inneholder stort sett kun obligatoriske egenskaper
+
+# begrepet 'organisatoriskEnhet':
+:organisatoriskEnhet a skos:Concept;  # Begrep
+  # --- mandatory, for selve begrepet:
+    dct:identifier <hhttps://examples.com/concepts/organisatoriskEnhet> ; # identifikator
+    skosxl:prefLabel [ a skosxl:Label ; # anbefaltTerm
+      skosxl:literalForm "organisatorisk enhet"@nb ; # navn
+      ] ;
+    skosno:definisjon [ a skosno:Definisjon ; # definisjon
+    	rdfs:label "her kommer definisjonsteksten ..."@nb ; # definisjonsteksten
+    	] ;
+    dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ; # ansvarligVirksomhet
+  # --- optional, herunder partitive relasjoner:
+    skosno:partitivRelasjon [ a skosno:PartitivRelasjon ;  # partitivRelasjon
+      # --- mandatory (minst 1 overordnetBegrep eller 1 underordetBegrep):
+        dct:isPartOf :virksomhet ; # overordnetBegrep
+      # --- optional:
+        dct:description "funksjon"@nb ; # inndelingskriterium
+      ] ;
+  .
+
+# begrepet 'geografiskEnhet':
+:geografiskEnhet a skos:Concept;  # Begrep
+  # --- mandatory, for selve begrepet:
+    dct:identifier <hhttps://examples.com/concepts/geografiskEnhet> ; # identifikator
+    skosxl:prefLabel [ a skosxl:Label ; # anbefaltTerm
+      skosxl:literalForm "geografisk enhet"@nb ; # navn
+      ] ;
+    skosno:definisjon [ a skosno:Definisjon ; # definisjon
+    	rdfs:label "her kommer definisjonsteksten ..."@nb ; # definisjonsteksten
+    	] ;
+    dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ; # ansvarligVirksomhet
+  .

--- a/ontology/skosno-v1.ttl
+++ b/ontology/skosno-v1.ttl
@@ -31,9 +31,9 @@
     dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ;
     dct:description "This is the ontology for SKOS-AP-NO-Begrep."@en ;
     dct:title "Ontology for SKOS-AP-NO-Begrep v.1.x"@en , "Ontologi for SKOS-AP-NO-Begrep v.1.x"@nb ;
-    dct:modified "2021-05-05"^^xsd:date ;
-    owl:versionInfo "0.1" ;
-    owl:versionNotes "Only the classes, properties and controlled vocabularies that are defined in SKOS-AP-NO-Begrep are defined in this ontology. Properties, classes etc. that are defined elsewhere and used in SKOS-AP-NO-Begrep without modification, are not (re)defined here."@en ;
+    dct:modified "2021-08-26"^^xsd:date ;
+    owl:versionInfo "0.2" ;
+    owl:versionNotes "Only the classes, properties and controlled vocabularies that are defined in SKOS-AP-NO-Begrep are defined in this ontology. Properties, classes etc. that are defined elsewhere and used in SKOS-AP-NO-Begrep without modification, are not (re)defined here - but with modifications documented here."@en ;
     foaf:homepage <https://github.com/Informasjonsforvaltning/skos-ap-no-begrep/ontology/> ;
     foaf:maker [
         foaf:mbox <mailto:informasjonsforvaltning@digdir.no> ;
@@ -172,7 +172,7 @@ skosno:inndelingskriterium a owl:DatatypeProperty ;
   rdfs:range rdfs:Literal ;
   rdfs:label "criterion of subdivision"@en , "inndelingskriterium"@nb ;
   rdfs:comment "To refer to a criterion of subdivision of the generic or partitive relation."@en ,
-      "For å oppgi inndelingskriteriet til en generisk eller partitiv relasjon."@nb ;
+      "For å oppgi et inndelingskriterium til en generisk eller partitiv relasjon."@nb ;
   rdfs:seeAlso <https://www.standard.no/toppvalg/termbasen/Termpost/?TermPostId=66217> ;
   .
 
@@ -264,7 +264,7 @@ dct:audience a owl:ObjectProperty ;
 
 ###
 ### Classes from other vocabularies that are used in SKOS-AP-NO-Begrep,
-### without modified usage, only with Norwegian label:
+### without modified usage, only with Norwegian labels:
 ###
 
 skos:Collection a owl:Class ;
@@ -281,34 +281,36 @@ skosxl:Label a owl:Class ;
 ### with Norwegian labels, and/or range/domain specified:
 ###
 
-### fylles på litt etter hvert (etter behov) ...
-
 skos:related a owl:ObjectProperty ;
-  rdfs:label "relatert begrep"@nb ;
+  rdfs:label "assosiert begrep"@nb , "related concept"@en ;
   rdfs:domain skosno:AssosiativRelasjon ;
   rdfs:range skos:Concept ;
  .
 
 xkos:generalizes a owl:ObjectProperty ;
-  rdfs:label "underordnet begrep (i en generisk relasjon)"@nb ;
+  rdfs:label "underordnet begrep (i en generisk relasjon)"@nb , "spesifikt begrep"@nb ,
+    "subordinate concept (in a generic relation)"@en , "specific concept"@en ;
   rdfs:domain skosno:GeneriskRelasjon ;
   rdfs:range skos:Concept ;
   .
 
 xkos:specializes a owl:ObjectProperty ;
-  rdfs:label "overordnet begrep (i en generisk relasjon)"@nb ;
+  rdfs:label "overordnet begrep (i en generisk relasjon)"@nb , "generisk begrep"@nb ,
+    "superordinate concept (in a generic relation)"@en , "generic concept"@en ;
   rdfs:domain skosno:GeneriskRelasjon ;
   rdfs:range skos:Concept ;
   .
 
 xkos:hasPart a owl:ObjectProperty ;
-  rdfs:label "underordnet begrep (i en partitiv relasjon)"@nb ;
+  rdfs:label "underordnet begrep (i en partitiv relasjon)"@nb , "delbegrep"@nb ,
+    "subordinate concept (in a partitive relation)"@en , "partitive concept"@en ;
   rdfs:domain skosno:PartitivRelasjon ;
   rdfs:range skos:Concept ;
   .
 
 xkos:isPartOf a owl:ObjectProperty ;
-  rdfs:label "overordnet begrep (i en partitiv relasjon)"@nb ;
+  rdfs:label "overordnet begrep (i en partitiv relasjon)"@nb , "helhetsbegrep"@nb ,
+    "superordinate concept (in a partitive relation)"@en , "comprehensive concept"@en ;
   rdfs:domain skosno:PartitivRelasjon ;
   rdfs:range skos:Concept ;
   .

--- a/shacl/README.md
+++ b/shacl/README.md
@@ -3,5 +3,4 @@
 This folder contains validation rules for SKOS-AP-NO-Begrep, as shacl-shapes.
 
 About the current version of the shacl-file:
-* Except for the 'concept relations', all relevant shapes are included, i.e., also shapes for optional properties and for usage of permitted values.
-* sh:targetObjectsOf is used for skos:Concept, in order to avoid validating of imported skos:Concept. However, as a consequence, skos:Concept which is not an object in a triple (e.g., as a skos:member, or referred to by dct:replaces/dct:isReplacedBy etc.) will not be validated.
+* All relevant shapes are included, i.e., also shapes for optional properties and for usage of permitted values.

--- a/shacl/SKOS-AP-NO-Begrep-shape_shape_v1.ttl
+++ b/shacl/SKOS-AP-NO-Begrep-shape_shape_v1.ttl
@@ -27,16 +27,16 @@
         foaf:name "Digitaliseringsdirektoratet"@nb , "Norwegian Digitalisation Agency"@en ;
     ];
     dct:license <http://publications.europa.eu/resource/authority/licence/CC_BY_4_0> ;
-    dct:modified "2021-08-24"^^xsd:date ;
+    dct:modified "2021-08-26"^^xsd:date ;
     rdfs:commet "Validated SUCCESS at https://www.itb.ec.europa.eu/shacl/shacl/upload"@en ;
     dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/991825827> ;
     dct:description "This document specifies the constraints on properties and classes expressed by SKOS-AP-NO-Begrep in SHACL."@en ;
     dct:title "The constraints of SKOS-AP-NO-Begrep"@en ;
-    owl:versionInfo "0.6";
-    owl:owl:versionInfo "Except for 'concept relations', all relevant shapes are included in this version, i.e., also for optional properties and for usage of permitted values. The shapes are tested using test concepts/collections with dummy values, though not all properties are tested with 'intended errors'."@en ;
+    owl:versionInfo "0.7" ;
+    owl:versionInfo "All relevant shapes are included in this version, i.e., also for optional properties and for usage of permissible values. The shapes are tested using test concepts/collections with dummy values, though not all properties are tested with 'intended errors'."@en ;
     foaf:homepage <https://github.com/Informasjonsforvaltning/skos-ap-no-begrep/shacl/> ;
     foaf:maker [
-        foaf:mbox <mailto:informasjonsforvaltning@diggir.no> ;
+        foaf:mbox <mailto:informasjonsforvaltning@digdir.no> ;
         foaf:name "Informasjonsforvaltning, Digitaliseringsdirektoratet"@nb ;
         foaf:page <https://www.digdir.no> ;
     ] .
@@ -140,7 +140,7 @@
     sh:property [ # assosiativ relasjon
       sh:name "assosiativ relasjon"@nb , "assosiative relation"@en ;
       sh:path skosno:assosiativRelasjon ;
-      sh:class skosno:AssosiativRelatjon ;
+      sh:class skosno:AssosiativRelasjon ;
       sh:severity sh:Violation ;
         ] ;
     sh:property [ # generisk relasjon
@@ -152,7 +152,7 @@
     sh:property [ # partitiv relasjon
       sh:name "partitiv relasjon"@nb , "partitive relation"@en ;
       sh:path skosno:partitivRelasjon ;
-      sh:class skosno:PartitiveRelasjon ;
+      sh:class skosno:PartitivRelasjon ;
       sh:severity sh:Violation ;
       ] ;
     sh:targetClass skos:Concept ;
@@ -225,6 +225,118 @@
         ] ;
     sh:targetObjectsOf skosno:definisjon , skosno:alternativFormulering ;
     .
+
+:AssosiativRelasjon_Shape a sh:NodeShape ; # AssosiativRelasjon
+  sh:name "Assosiativ relasjon"@nb , "Associative relation"@en ;
+  sh:property [ # assosiert begrep
+    sh:name "assosiert begrep"@nb, "associated concept"@en ;
+    sh:minCount 1 ;
+    sh:path skos:related ;
+    sh:class skos:Concept ;
+    sh:severity sh:Violation ;
+    sh:message "En assosiativ relasjon skal ha minst 1 assosiert begrep som skal være en instans av skos:Concept."@nb , "An associative relation shall have at least 1 associated concept (skos:related), which shall be an instance of skos:Concept.";
+    ] ;
+  sh:property [ # beskrivelse
+    sh:name "beskrivelse"@nb , "description"@en ;
+    sh:minCount 1 ;
+    sh:path dct:description ;
+    sh:nodeKind sh:Literal ;
+    sh:severity sh:Violation ;
+    sh:message "En assosiativ relasjon skal ha minst 1 beskrivelse av relasjonen, som skal være av type Literal."@nb , "An associative relation shall have at least 1 description, which shall be Literal.";
+    ] ;
+  sh:property [ # sist oppdatert
+      sh:name "sist oppdatert"@nb , "modified"@en ;
+      sh:maxCount 1 ;
+      sh:path dct:modified ;
+      sh:severity sh:Violation ;
+      sh:shape :DateOrDateTimeDataType_Shape ;
+      sh:message "Associativ relasjon kan ha maks. 1 sist oppdatert dato (dct:modified), som skal være enten xsd:date eller xsd:dateTime."@nb , "An associative relation may have at most 1 modified date (dct:modified), which shall be either xsd:date of xsd:dateTime.";
+      ] ;
+    sh:targetClass skosno:AssosiativRelasjon ;
+    .
+
+:GeneriskBegrep_Shape a sh:NodeShape ; # Generisk/overordnet begrep, brukes i Generisk relasjon
+  sh:name "overordnet/generisk begrep"@nb, "superordinate/generic concept"@en ;
+  sh:property [ # overordnet begrep
+    sh:minCount 1 ;
+    sh:path xkos:specializes ;
+    sh:class skos:Concept ;
+    sh:severity sh:Violation ;
+    ] ;
+    .
+
+:SpesifiktBegrep_Shape a sh:nodeKind ; # Spesifikt/underordnet begrep, brukes i Generisk relasjon
+  sh:name "underordnet/spesifikt begrep"@nb, "subordinate/specific concept"@en , "specific concept"@en ;
+  sh:property [ # underordnet begrep
+    sh:minCount 1 ;
+    sh:path xkos:generalizes ;
+    sh:class skos:Concept ;
+    sh:severity sh:Violation ;
+    ] ;
+    .
+
+:GeneriskSpesifiktBegrep_Shape a sh:NodeShape ; # Gnerisk eller spesifkt begrep
+  sh:name "generisk/overordnet eller spesifikt/underordnet begrep"@nb , "Generic/superordinate or specific/subordinate concept"@en ;
+  sh:or ( # overordnet eller underordnet begrep
+        [ sh:node :GeneriskBegrep_Shape ; ]
+        [ sh:node :SpesifiktBegrep_Shape ; ] ) ;
+  sh:severity sh:Violation ;
+  sh:message "En generisk relasjon skal ha minst 1 overordnet begrep (xkos:specializes) eller 1 underordnet begrep (xkos:generalizes), som skal være instans av skos:Concept."@nb , "A generic relation shall have at least 1 superordinate concept (xkos:specializes) or 1 subordinate concept (xkos:generalizes), which shall be an intance of skos:Concept.";
+  sh:targetClass skosno:GeneriskRelasjon ;
+  .
+
+:Inndelingskriterium_Shape a sh:NodeShape ; # Inndelingskriterium for GeneriskRelasjon eller PartitivRelasjon
+  sh:property [ # beskrivelse
+    sh:name "inndelingskriterium"@nb , "subdivision criterion"@en ;
+    sh:path dct:description ;
+    sh:nodeKind sh:Literal ;
+    sh:severity sh:Violation ;
+    sh:message "Inndelingskriterium (dct:description) skal være av type Literal."@nb ;
+    ] ;
+    sh:targetClass skosno:PartitivRelasjon , skosno:GeneriskRelasjon ;
+    .
+
+:SistOppdatertRelasjon_Shape a sh:NodeShape ; # Sist oppdatert for AssosiativRelasjon, GeneriskRelasjon eller PartitivRelasjon
+  sh:property [ # sist oppdatert
+      sh:name "sist oppdatert"@nb , "modified"@en ;
+      sh:maxCount 1 ;
+      sh:path dct:modified ;
+      sh:severity sh:Violation ;
+      sh:shape :DateOrDateTimeDataType_Shape ;
+      sh:message "Maks. 1 sist oppdatert dato (dct:modified) tillatt, den skal være enten xsd:date eller xsd:dateTime."@nb ;
+      ] ;
+      sh:targetClass skosno:PartitivRelasjon , skosno:GeneriskRelasjon ;
+    .
+
+:Helhetsbegrep_Shape a sh:NodeShape ; # brukes i PartitivRelasjon_Shape
+  sh:name "helhetsbegrep-restriksjon"@nb, "comprehensive concept restrictions"@en ;
+  sh:property [
+    sh:minCount 1 ;
+    sh:path dct:isPartOf ;
+    sh:class skos:Concept ;
+    sh:severity sh:Violation ;
+    ] ;
+    .
+
+:Delbegrep_Shape a sh:NodeShape ; # brukes i PartitivRelasjon_Shape
+  sh:name "delbegrep-restriksjon"@nb, "partitive concept restrictions"@en ;
+  sh:property [
+    sh:minCount 1 ;
+    sh:path dct:hasPart ;
+    sh:class skos:Concept ;
+    sh:severity sh:Violation ;
+    ] ;
+    .
+
+:HelhetDelbegrep_shape a sh:NodeShape ; # slå sammen Helhetsbegrep_Shape og Delbegrep_Shape
+  sh:name "Overordnet/helhets- eller 1 underordnet/del- begrep"@nb ;
+  sh:or ( # overordnet eller underordnet begrep
+        [ sh:node :Helhetsbegrep_Shape ; ]
+        [ sh:node :Delbegrep_Shape ; ] ) ;
+  sh:severity sh:Violation ;
+  sh:message "En partitiv relasjon skal ha minst 1 overordnet begrep (dct:isPartOf) eller underordnet begrep (dct:hasPart), som skal være instans av skos:Concept."@nb , "A partitive relation shall have at least 1 superordinate concept (dct:isPartOf) or 1 subordinate concept (dct:hasPart), which shall be an instance of skos:Concept.";
+  sh:targetClass skosno:PartitivRelasjon ;
+  .
 
 :Collection_Shape a sh:NodeShape ; # Begrepssamling
     ### mandatory properties:
@@ -305,7 +417,8 @@
     rdfs:comment "Date time date disjunction shape checks that a datatype property receives a date or a dateTime literal" ;
     sh:name "Date time date disjunction" ;
     sh:message "The values must be typed as either xsd:date or xsd:dateTime" ;
-    sh:or ([ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ]
+    sh:severity sh:Violation ;
+    sh:xone ([ sh:datatype xsd:date ] [ sh:datatype xsd:dateTime ]
     ) ;
     .
 


### PR DESCRIPTION
Legger til komplette eksempler på assosiative relasjoner, generiske relasjoner og partitive relasjoner mellom begreper, med "tilhørende" oppdateringer av shacl og ontologi.

Del 2 av håndteringen av Issue #111. 