### PR TITLE
Redaksjonelt, retter opp include-feil

### DIFF
--- a/docs/main.adoc
+++ b/docs/main.adoc
@@ -19,7 +19,7 @@ include::shared/download.adoc[]
 *Status*: #under arbeid# +
 *Versjon*: #forberedelse til høringsversjon# +
 *Publisert*: #ikke ennå# +
-*Oppdatert*: 2022-09-02 #løpende oppdateres# +
+*Oppdatert*: 2022-09-05 #løpende oppdateres# +
 *Gjeldende versjon*: https://data.norge.no/specification/skos-ap-no-begrep/ +
 *Redaktørens utkast*: https://informasjonsforvaltning.github.io/skos-ap-no-begrep/
 
@@ -67,7 +67,7 @@ include::KlassenPartitivBegrepsrelasjon.adoc[]
 
 include::KlassenBegrepssamling.adoc[]
 
-include::Navnerom.adoc[]
+include::navnerom.adoc[]
 
 include::ForenkledeModeller.adoc[]
 


### PR DESCRIPTION
Forskjell mellom stor og liten bokstav i filnavnet gjorde at en fil ikke ble tatt med i genereringen på serveren (men ok lokalt i Windows).  Rettes opp her.