### PR TITLE
Tar bort muligheten for å innmelde feil

### DIFF
--- a/docs/main.adoc
+++ b/docs/main.adoc
@@ -30,9 +30,6 @@ toc::[]
 //{description}
 include::shared/download.adoc[]
 
-NOTE: *Innmelding av feil og mangler:* +
-Dersom du finner feil eller mangler i dokumentet, ber vi om at dette meldes inn på https://github.com/Informasjonsforvaltning/skos-ap-no-begrep/issues[Github Issues]. Dersom du ikke allerede har bruker på Github kan du opprette bruker gratis.
-
 // :leveloffset: +1
 
 // Innhold her.


### PR DESCRIPTION
... fordi v1 av skos-ap-no-begrep fases ut og ikke skal vedlikeholdes lenger, da bør det ikke være mulig å melde inn feil på denne.