### PR TITLE
develop -> v2

### DIFF
--- a/.github/workflows/adocs-build-and-publish-v2-production.yml
+++ b/.github/workflows/adocs-build-and-publish-v2-production.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           ontology-type: "specification"
           ontology: "skos-ap-no-begrep"
-          host: "https://fellesdatakatalog.digdir.no"
+          host: "https://data.norge.no"
           api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
           files: |
             docs/index.html text/html nb


### PR DESCRIPTION
Få oppdatert workflow fra develop-branch til v2-branch. Dette fordi publisering til data.norge.no feilet ved forrige forsøk, selv om usikker på om dette var årsaken (siden det fungerte tidligere), forsøker jeg å retter opp mulig feil i workflow'en. 