### PR TITLE
chore: migrate to reusable workflows

### DIFF
--- a/.github/workflows/adocs-build-and-publish-develop.yml
+++ b/.github/workflows/adocs-build-and-publish-develop.yml
@@ -2,7 +2,6 @@ name: Build adocs and publish develop to GitHub pages
 
 permissions:
   contents: write
-  pages: write
 
 on:
   push:
@@ -13,37 +12,17 @@ on:
   workflow_dispatch:
 
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
+  build-adocs:
     name: asciidoctor build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor-pdf -D docs -o files/skos-ap-no-begrep.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-github-pages.yaml@main
+    with:
+      ref: develop
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/skos-ap-no-begrep.pdf -a lang=nb docs/main.adoc
+      program_pdf_continue_on_error: true
+      publish_branch: gh-pages
+      publish_dir: ./docs
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/adocs-build-and-publish-v2-production.yml
+++ b/.github/workflows/adocs-build-and-publish-v2-production.yml
@@ -12,52 +12,29 @@ on:
   workflow_dispatch:
 
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-
-    steps:
-      - name: Checkout v2 branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          ref: v2
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor-pdf -D docs -o files/skos-ap-no-begrep.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-
-      - name: Upload rdf to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@84beeeacd364f310ef6a253bc079354cdf62e5dd
-        id: upload-rdf
-        with:
-          ontology-type: "specification"
-          ontology: "skos-ap-no-begrep"
-          host: "https://data.norge.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
-          files: |
-            docs/index.html text/html nb
-            docs/files/skos-ap-no-begrep.pdf application/pdf nb files/skos-ap-no-begrep.pdf
-            docs/images/Digdir.png image/png nb images/Digdir.png
-            docs/images/RDF-eksempel-assosiativrelasjon.png image/png nb images/RDF-eksempel-assosiativrelasjon.png
-            docs/images/RDF-eksempel-definisjon-1.png image/png nb images/RDF-eksempel-definisjon-1.png
-            docs/images/RDF-eksempel-definisjon-2.png image/png nb images/RDF-eksempel-definisjon-2.png
-            docs/images/RDF-eksempel-partitivrelasjon.png image/png nb images/RDF-eksempel-partitivrelasjon.png
-            docs/images/SKOS-AP-NO-Begrep-kun-med-begrepsrelasjoner.png image/png nb images/SKOS-AP-NO-Begrep-kun-med-begrepsrelasjoner.png
-            docs/images/SKOS-AP-NO-Begrep-kun-obligatoriske.png image/png nb images/SKOS-AP-NO-Begrep-kun-obligatoriske.png
-            docs/images/SKOS-AP-NO-Begrep-uten-relasjoner.png image/png nb images/SKOS-AP-NO-Begrep-uten-relasjoner.png
+  upload-files-to-production:
+    name: Upload specification to static-rdf-server
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v2
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/skos-ap-no-begrep.pdf -a lang=nb docs/main.adoc
+      program_pdf_continue_on_error: true
+      host: https://data.norge.no
+      ontology: skos-ap-no-begrep
+      ontology-type: specification
+      files: |
+        docs/index.html text/html nb
+        docs/files/skos-ap-no-begrep.pdf application/pdf nb files/skos-ap-no-begrep.pdf
+        docs/images/Digdir.png image/png nb images/Digdir.png
+        docs/images/RDF-eksempel-assosiativrelasjon.png image/png nb images/RDF-eksempel-assosiativrelasjon.png
+        docs/images/RDF-eksempel-definisjon-1.png image/png nb images/RDF-eksempel-definisjon-1.png
+        docs/images/RDF-eksempel-definisjon-2.png image/png nb images/RDF-eksempel-definisjon-2.png
+        docs/images/RDF-eksempel-partitivrelasjon.png image/png nb images/RDF-eksempel-partitivrelasjon.png
+        docs/images/SKOS-AP-NO-Begrep-kun-med-begrepsrelasjoner.png image/png nb images/SKOS-AP-NO-Begrep-kun-med-begrepsrelasjoner.png
+        docs/images/SKOS-AP-NO-Begrep-kun-obligatoriske.png image/png nb images/SKOS-AP-NO-Begrep-kun-obligatoriske.png
+        docs/images/SKOS-AP-NO-Begrep-uten-relasjoner.png image/png nb images/SKOS-AP-NO-Begrep-uten-relasjoner.png
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}

--- a/.github/workflows/publish-ontology-to-production.yml
+++ b/.github/workflows/publish-ontology-to-production.yml
@@ -12,44 +12,20 @@ on:
   workflow_dispatch:
 
 jobs:
-  adoc_build_and_upload:
-    name: Adoc-build html and Upload vocabulary to static-rdf-server
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          ref: v2
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html nb
-        id: adocbuild_html_nb
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor -a data-uri -D ontology -o index-nb.html -a lang=nb ontology/main-nb.adoc"
-
-      - name: Build html en
-        id: adocbuild_html_en
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor -a data-uri -D ontology -o index-en.html -a lang=en ontology/main-en.adoc"
-
-      - name: Upload files to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@84beeeacd364f310ef6a253bc079354cdf62e5dd
-        id: upload-files
-        with:
-          ontology-type: "vocabulary"
-          ontology: "skosno"
-          host: "https://data.norge.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
-          files: |
-            ontology/skosno.ttl text/turtle en
-            ontology/index-en.html text/html en
-            ontology/index-nb.html text/html nb
+  upload-files-to-production:
+    name: Upload vocabulary to static-rdf-server
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v2
+      program_html: |
+        asciidoctor -a data-uri -D ontology -o index-en.html -a lang=en ontology/main-en.adoc
+        asciidoctor -a data-uri -D ontology -o index-nb.html -a lang=nb ontology/main-nb.adoc
+      host: https://data.norge.no
+      ontology: skosno
+      ontology-type: vocabulary
+      files: |
+        ontology/skosno.ttl text/turtle en
+        ontology/index-en.html text/html en
+        ontology/index-nb.html text/html nb
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}


### PR DESCRIPTION
# Summary

Migrate the three GitHub Actions workflows to the centralized
Informasjonsforvaltning/workflows reusable specification-* workflows.

- Replace local build/publish steps with `specification-github-pages.yaml@main` (develop → GitHub Pages)
- Replace both production publishers with `specification-upload-files.yaml@main` (v2 → data.norge.no)
- Pin checkout to deploy branch via `ref` so `workflow_dispatch` can't publish arbitrary branch content
- Resolves #253 (third-party actions now SHA-pinned inside the reusable workflows; drops unpinned `@master` asciidoctor action)
- Resolves #256 (`workflow_dispatch` branch-restriction bypass)

Note: takes effect on `v2`/`v1` once merged forward — see follow-up PRs targeting those branches. Version-input question tracked in #260.