### PR TITLE
chore: migrate to reusable workflows

### DIFF
--- a/.github/workflows/adocs-build-and-publish-v1-production.yml
+++ b/.github/workflows/adocs-build-and-publish-v1-production.yml
@@ -1,5 +1,8 @@
 name: Build adocs and publish v1 to production
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -9,46 +12,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-
-    steps:
-      - name: Checkout v1 branch
-        uses: actions/checkout@v4
-        with:
-          ref: v1
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor-pdf -D docs -o files/skos-ap-no-begrep-v1xx.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-
-      - name: Upload rdf to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.2.0
-        id: upload-rdf
-        with:
-          ontology-type: "specification"
-          ontology: "skos-ap-no-begrep"
-          version: "v1.1"
-          host: "https://fellesdatakatalog.digdir.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
-          files: |
-            docs/index.html text/html nb
-            docs/files/skos-ap-no-begrep-v1xx.pdf application/pdf nb files/skos-ap-no-begrep-v1xx.pdf
-            docs/images/digitaliseringsdirektoratet.png image/png nb images/digitaliseringsdirektoratet.png
+  upload-files-to-production:
+    name: Upload specification to static-rdf-server
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v1
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/skos-ap-no-begrep-v1xx.pdf -a lang=nb docs/main.adoc
+      program_pdf_continue_on_error: true
+      host: https://fellesdatakatalog.digdir.no
+      ontology: skos-ap-no-begrep
+      ontology-type: specification
+      version: v1.1
+      files: |
+        docs/index.html text/html nb
+        docs/files/skos-ap-no-begrep-v1xx.pdf application/pdf nb files/skos-ap-no-begrep-v1xx.pdf
+        docs/images/digitaliseringsdirektoratet.png image/png nb images/digitaliseringsdirektoratet.png
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}


### PR DESCRIPTION
# Summary

Migrate the v1 production publish workflow to the centralized
Informasjonsforvaltning/workflows reusable `specification-upload-files.yaml@main`.

- Replace local build/publish steps with the reusable workflow (v1 → data.norge.no)
- Preserve v1-specific values: `host` (fellesdatakatalog.digdir.no), `version: v1.1`, PDF name, image
- Pin checkout to `v1` via `ref` so `workflow_dispatch` can't publish arbitrary branch content
- Part of the workflow migration also done on `develop`/`v2` — applies the #253/#256 fixes to the frozen `v1` branch (drops unpinned `@v4`/`@master`/`@v3.2.0` actions)